### PR TITLE
Fix up Buffer usage in example.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.nyc_output

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Encode/decode value as bitcoin `OP_PUSHDATA` integer
 ## Example
 
 ``` javascript
-var pushdata = require('pushdata-bitcoin')
+const pushdata = require('pushdata-bitcoin')
 
-var i = 120
-var buffer = new Buffer(pushdata.encodingLength(i))
+let i = 120
+let buffer = Buffer.alloc(pushdata.encodingLength(i))
 
 pushdata.encode(buffer, i)
 ```

--- a/index.js
+++ b/index.js
@@ -2,12 +2,13 @@ var OPS = require('bitcoin-ops')
 
 function encodingLength (i) {
   return i < OPS.OP_PUSHDATA1 ? 1
-  : i <= 0xff ? 2
-  : i <= 0xffff ? 3
-  : 5
+    : i <= 0xff ? 2
+      : i <= 0xffff ? 3
+        : 5
 }
 
 function encode (buffer, number, offset) {
+  offset = offset || 0
   var size = encodingLength(number)
 
   // ~6 bit

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "unit": "tape test/*.js"
   },
   "devDependencies": {
-    "nyc": "^6.4.0",
+    "nyc": "^13.1.0",
     "standard": "*",
     "tape": "^4.5.1"
   },

--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -57,7 +57,10 @@
     {
       "description": "OP_PUSHDATA4, no size",
       "hex": "4e"
+    },
+    {
+      "description": "invalid PUSHDATA OP, no size",
+      "hex": "4fffffffff"
     }
   ]
 }
-

--- a/test/index.js
+++ b/test/index.js
@@ -9,7 +9,7 @@ fixtures.valid.forEach(function (f) {
     var size = pushdata.encodingLength(f.dec)
     t.strictEqual(size, f.hex.length / 2)
 
-    var buffer = new Buffer(f.hex, 'hex')
+    var buffer = Buffer.from(f.hex, 'hex')
     var d = pushdata.decode(buffer, 0)
 
     t.strictEqual(d.opcode, fopcode)
@@ -26,8 +26,15 @@ fixtures.invalid.forEach(function (f) {
   tape('Invalid for ' + f.description, function (t) {
     t.plan(1)
 
-    var buffer = new Buffer(f.hex, 'hex')
-    var n = pushdata.decode(buffer, 0)
+    var buffer = Buffer.from(f.hex, 'hex')
+    var n
+    try {
+      n = pushdata.decode(buffer, 0)
+    } catch (err) {
+      if (f.hex === '4fffffffff' && err.message === 'Unexpected opcode') {
+        n = null
+      }
+    }
     t.strictEqual(n, null)
   })
 })


### PR DESCRIPTION
This PR fixes:

1. gitignore missing.
2. new Buffer() in README example
3. coverage was missing one branch.
4. The example in the README fails because offset is undefined, so default to 0.